### PR TITLE
Fix example to show setting `requestContentType` before `body`

### DIFF
--- a/src/site/examples.txt
+++ b/src/site/examples.txt
@@ -170,8 +170,8 @@ def http = new HTTPBuilder('http://twitter.com/statuses/')
 // auth omitted...
 http.request( POST ) {
   uri.path = 'update.xml'
-  body =  [ status : 'update!' , source : 'httpbuilder' ]
   requestContentType = ContentType.URLENC
+  body =  [ status : 'update!' , source : 'httpbuilder' ]
 
   response.success = { resp ->
     println "Tweet response status: ${resp.statusLine}"


### PR DESCRIPTION
I'm new to HTTPBuilder, so maybe I got this wrong, but I used this example as a starting point and it wouldn't work properly unless I set `requestContentType` to ContentType.URLENC before setting the `body` to a params Map.
