### PR TITLE
Fix URIBuilder groovy example

### DIFF
--- a/src/main/java/groovyx/net/http/URIBuilder.java
+++ b/src/main/java/groovyx/net/http/URIBuilder.java
@@ -52,6 +52,7 @@ import org.apache.http.message.BasicNameValuePair;
  *    port = 443
  *    path = 'some/path'
  *    query = [p1:1, p2:'two']
+ *    return it
  * }.toString()
  * </pre>
  * @author <a href='mailto:tomstrummer+httpbuilder@gmail.com'>Tom Nichols</a>


### PR DESCRIPTION
The .with closure returns the last result, not the object.

Old example:

```
groovy> import groovyx.net.http.URIBuilder
groovy> new URIBuilder('http://www.google.com/').with {
groovy>     scheme = 'https'
groovy>     port = 443
groovy>     path = 'some/path'
groovy>     query = [p1:1, p2:'two']
groovy> }

["p1":1, "p2":"two"]
```

New example:

```
groovy> new URIBuilder('http://www.google.com/').with {
groovy>     scheme = 'https'
groovy>     port = 443
groovy>     path = 'some/path'
groovy>     query = [p1:1, p2:'two']
groovy>     return it
groovy> }

https://www.google.com:443/some/path?p1=1&p2=two
```
