### PR TITLE
Added NTLM support in AuthConfig

### DIFF
--- a/src/main/java/groovyx/net/http/AuthConfig.java
+++ b/src/main/java/groovyx/net/http/AuthConfig.java
@@ -42,6 +42,7 @@ import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.ssl.SSLSocketFactory;
@@ -85,6 +86,36 @@ public class AuthConfig {
         builder.getClient().getCredentialsProvider().setCredentials(
             new AuthScope( host, port ),
             new UsernamePasswordCredentials( user, pass )
+        );
+    }
+
+    /**
+     * Set NTLM authentication credentials to be used for the current
+     * {@link HTTPBuilder#getUri() default host}.
+     * @param user
+     * @param pass
+     * @param workstation
+     * @param domain
+     */
+    public void ntlm( String user, String pass, String workstation, String domain ) {
+        URI uri = ((URIBuilder)builder.getUri()).toURI();
+        if ( uri == null ) throw new IllegalStateException( "a default URI must be set" );
+        this.ntlm( uri.getHost(), uri.getPort(), user, pass, workstation, domain );
+    }
+
+    /**
+     * Set NTLM authentication credentials to be used for the given host and port.
+     * @param host
+     * @param port
+     * @param user
+     * @param pass
+     * @param workstation
+     * @param domain
+     */
+    public void ntlm( String host, int port, String user, String pass, String workstation, String domain ) {
+        builder.getClient().getCredentialsProvider().setCredentials(
+            new AuthScope( host, port ),
+            new NTCredentials( user, pass, workstation, domain )
         );
     }
 


### PR DESCRIPTION
HTTPClient won't use UsernamePasswordCredentials for NTLM authentication, so I've added an nltm method to AuthConfig to create an NTCredentials object.
