### PR TITLE
Should throw exception if content type is not set.

### DIFF
--- a/src/main/java/groovyx/net/http/HTTPBuilder.java
+++ b/src/main/java/groovyx/net/http/HTTPBuilder.java
@@ -1201,6 +1201,11 @@ public class HTTPBuilder {
                         "Cannot set a request body for a " + request.getMethod() + " method" );
             Closure encoder = encoders.getAt( this.getRequestContentType() );
 
+            // Either content type or encoder is empty.
+            if ( encoder == null )
+                throw new IllegalArgumentException(
+                        "Cannot set a request body without proper content type set" );
+
             HttpEntity entity = encoder.getMaximumNumberOfParameters() == 2
                     ? (HttpEntity)encoder.call( new Object[] { body, this.getRequestContentType() } )
                     : (HttpEntity)encoder.call( body );

--- a/src/test/groovy/groovyx/net/http/HTTPBuilderTest.groovy
+++ b/src/test/groovy/groovyx/net/http/HTTPBuilderTest.groovy
@@ -1,22 +1,12 @@
 package groovyx.net.http
-
-import static groovyx.net.http.Method.*
-import static groovyx.net.http.ContentType.*
-
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.Reader
-import java.io.ByteArrayOutputStream
-import java.lang.AssertionError
-import java.net.ServerSocket
-import groovy.util.XmlSlurper
 import groovy.util.slurpersupport.GPathResult
-import org.apache.commons.io.IOUtils
 import org.apache.http.client.HttpResponseException
-import org.apache.http.params.HttpConnectionParams
-import org.apache.xml.resolver.tools.CatalogResolver
 import org.junit.Ignore
 import org.junit.Test
+
+import static groovyx.net.http.ContentType.*
+import static groovyx.net.http.Method.*
+import static org.junit.Assert.fail
 
 class HTTPBuilderTest {
 
@@ -342,6 +332,14 @@ class HTTPBuilderTest {
             throw new AssertionError("request should have failed due to invalid kwarg.")
         }
         catch ( IllegalArgumentException ex ) { /* Expected result */ }
+    }
+
+    @Test(expected = IllegalArgumentException)
+    public void testShouldThrowExceptionIfContentTypeIsNotSet() {
+        new HTTPBuilder( 'http://weather.yahooapis.com/forecastrss' ).request(POST) { request ->
+            body = [p:'02110',u:'f']
+        }
+        fail("request should have failed due to unset content type.")
     }
 
     @Test public void testJSONPost() {


### PR DESCRIPTION
I've found an issue on setting body to POST request without setting content type first. I submit a patch to fix it.
