### PR TITLE
Changes to allow HTTPBuilder.client field to be any implementation of HttpClient

### DIFF
--- a/src/main/java/groovyx/net/http/AuthConfig.java
+++ b/src/main/java/groovyx/net/http/AuthConfig.java
@@ -43,8 +43,10 @@ import org.apache.http.HttpRequest;
 import org.apache.http.HttpRequestInterceptor;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.HttpClient;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.client.AbstractHttpClient;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
 
@@ -82,7 +84,11 @@ public class AuthConfig {
      * @param pass
      */
     public void basic( String host, int port, String user, String pass ) {
-        builder.getClient().getCredentialsProvider().setCredentials(
+	  final HttpClient client = builder.getClient();
+	  if ( !(client instanceof AbstractHttpClient )) {
+		throw new IllegalStateException("client is not an AbstractHttpClient");
+	  }
+      ((AbstractHttpClient)client).getCredentialsProvider().setCredentials(
             new AuthScope( host, port ),
             new UsernamePasswordCredentials( user, pass )
         );
@@ -130,9 +136,13 @@ public class AuthConfig {
      */
     public void oauth( String consumerKey, String consumerSecret,
             String accessToken, String secretToken ) {
-        this.builder.getClient().removeRequestInterceptorByClass( OAuthSigner.class );
+        	  final HttpClient client = builder.getClient();
+	    if ( !(client instanceof AbstractHttpClient )) {
+		  throw new IllegalStateException("client is not an AbstractHttpClient");
+	    }
+        ((AbstractHttpClient)client).removeRequestInterceptorByClass( OAuthSigner.class );
         if ( consumerKey != null )
-            this.builder.getClient().addRequestInterceptor( new OAuthSigner(
+            ((AbstractHttpClient)client).addRequestInterceptor( new OAuthSigner(
                 consumerKey, consumerSecret, accessToken, secretToken ) );
     }
 

--- a/src/main/java/groovyx/net/http/HTTPBuilder.java
+++ b/src/main/java/groovyx/net/http/HTTPBuilder.java
@@ -53,6 +53,7 @@ import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.params.ConnRoutePNames;
 import org.apache.http.cookie.params.CookieSpecPNames;
+import org.apache.http.client.HttpClient;
 import org.apache.http.impl.client.AbstractHttpClient;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.params.BasicHttpParams;
@@ -164,7 +165,7 @@ import org.codehaus.groovy.runtime.MethodClosure;
  */
 public class HTTPBuilder {
 
-    private AbstractHttpClient client;
+    private HttpClient client;
     protected URIBuilder defaultURI = null;
     protected AuthConfig auth = new AuthConfig( this );
 
@@ -756,7 +757,13 @@ public class HTTPBuilder {
      * string that is known by the {@link ContentEncodingRegistry}
      */
     public void setContentEncoding( Object... encodings ) {
-        this.contentEncodingHandler.setInterceptors( getClient(), encodings );
+	  	HttpClient client = getClient();
+		if ( client instanceof AbstractHttpClient ) {
+          this.contentEncodingHandler.setInterceptors( (AbstractHttpClient)client, encodings );
+		} else {
+		  throw new IllegalStateException("The HttpClient is not an AbstractHttpClient!");
+		}
+
     }
 
     /**
@@ -811,7 +818,7 @@ public class HTTPBuilder {
      * Return the underlying HTTPClient that is used to handle HTTP requests.
      * @return the client instance.
      */
-    public AbstractHttpClient getClient() {
+    public HttpClient getClient() {
         if (client == null) {
             HttpParams defaultParams = new BasicHttpParams();
             defaultParams.setParameter( CookieSpecPNames.DATE_PATTERNS,
@@ -821,7 +828,7 @@ public class HTTPBuilder {
         return client;
     }
 
-    public void setClient(AbstractHttpClient client) {
+    public void setClient(HttpClient client) {
         this.client = client;
     }
 
@@ -831,7 +838,7 @@ public class HTTPBuilder {
      * @param params
      * @return
      */
-    protected AbstractHttpClient createClient( HttpParams params ) {
+    protected HttpClient createClient( HttpParams params ) {
         return new DefaultHttpClient(params);
     }
 


### PR DESCRIPTION
The current code restricts the HttpClient to be a descendant of AbstractHttpClient.  The newer versions of HttpClient have moved away from using this base class exclusively.

This code makes the code run with exceptions being thrown when the functionality of AbstractHttpClient is required.  Specifically this includes the "basic" and "oauth" methods on AuthConfig, and "setContentEncoding" in HTTPBuilder.

I would imagine it would be best to do something about both of these that can work with a generic HttpClient instead of a descendant of AbstractHttpClient but my use case used neither so I did not attempt it.
