### PR TITLE
Removed super from get and post to support overriding of doRequest

### DIFF
--- a/src/main/java/groovyx/net/http/RESTClient.java
+++ b/src/main/java/groovyx/net/http/RESTClient.java
@@ -116,7 +116,7 @@ public class RESTClient extends HTTPBuilder {
      */
     public Object get( Map<String,?> args ) throws ClientProtocolException,
             IOException, URISyntaxException {
-        return super.doRequest( new RequestConfigDelegate( args, new HttpGet(), null ) );
+        return doRequest( new RequestConfigDelegate( args, new HttpGet(), null ) );
     }
 
     /**
@@ -138,7 +138,7 @@ public class RESTClient extends HTTPBuilder {
      */
     @Override public Object post( Map<String,?> args )
             throws URISyntaxException, ClientProtocolException, IOException {
-        return super.doRequest( new RequestConfigDelegate( args, new HttpPost(), null ) );
+        return doRequest( new RequestConfigDelegate( args, new HttpPost(), null ) );
     }
 
     /**


### PR DESCRIPTION
get and post method does `super.doRequest` but it prevents any override of the `doRequest` method, it should be just `doRequest(...`
