### PR TITLE
fix handling of timed out HttpURLClient requests with contentType.ANY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+*.iml
+.idea/

--- a/src/main/java/groovyx/net/http/ParserRegistry.java
+++ b/src/main/java/groovyx/net/http/ParserRegistry.java
@@ -361,9 +361,11 @@ public class ParserRegistry {
      * @param contentType
      * @return parser that can interpret the given response content type,
      *   or the default parser if no parser is registered for the given
-     *   content-type.  It should NOT return a null value.
+     *   content-type.
      */
     public Closure getAt( Object contentType ) {
+        if ( contentType == null ) return defaultParser;
+
         String ct = contentType.toString();
         int idx = ct.indexOf( ';' );
         if ( idx > 0 ) ct = ct.substring( 0, idx );

--- a/src/test/groovy/groovyx/net/http/HttpURLClientTest.groovy
+++ b/src/test/groovy/groovyx/net/http/HttpURLClientTest.groovy
@@ -2,17 +2,10 @@ package groovyx.net.http
 
 import org.junit.Ignore
 import org.junit.Test
-import java.lang.AssertionError
-import java.io.Reader
-import java.io.StringReader;
 
-import groovy.util.XmlSlurper
-import groovy.util.slurpersupport.GPathResult
 import org.apache.http.client.HttpResponseException
-import java.io.ByteArrayOutputStream
 import static groovyx.net.http.ContentType.*
 import static groovyx.net.http.Method.*
-import org.apache.xml.resolver.tools.CatalogResolver
 
 class HttpURLClientTest {
 
@@ -236,5 +229,10 @@ class HttpURLClientTest {
             assert false : "Unknown argument should have thrown exception"
         }
         catch ( IllegalArgumentException ex ) { /* Expected exception */ }
+    }
+
+    @Test(expected = SocketTimeoutException)
+    void testTimeout() {
+        new HttpURLClient(url: 'https://www.google.com/').request(timeout: 1)
     }
 }


### PR DESCRIPTION
Timed out HttpURLClient requests with contentType: ContentType.ANY (default value) fail with NullPointerException instead of throwing SocketTimeoutException

``` groovy
new HttpURLClient(url: 'http://www.google.com').request(timeout: 1)
```

``` java
java.lang.NullPointerException
    at groovyx.net.http.ParserRegistry.getAt(ParserRegistry.java:367)
    at groovyx.net.http.HttpURLClient.getparsedResult(HttpURLClient.java:256)
    at groovyx.net.http.HttpURLClient.request(HttpURLClient.java:237)
```
