### PR TITLE
requestContentType is added as a argument to encode method

### DIFF
--- a/src/main/java/groovyx/net/http/EncoderRegistry.java
+++ b/src/main/java/groovyx/net/http/EncoderRegistry.java
@@ -204,10 +204,6 @@ public class EncoderRegistry implements Iterable<Map.Entry<String,Closure>> {
      * @return an {@link HttpEntity} encapsulating this request data
      * @throws UnsupportedEncodingException
      */
-    public UrlEncodedFormEntity encodeForm( Map<?,?> params )
-            throws UnsupportedEncodingException {
-        return encodeForm( params, null );
-    }
 
     public UrlEncodedFormEntity encodeForm( Map<?,?> params, Object contentType )
             throws UnsupportedEncodingException {

--- a/src/main/java/groovyx/net/http/HttpURLClient.java
+++ b/src/main/java/groovyx/net/http/HttpURLClient.java
@@ -205,7 +205,7 @@ public class HttpURLClient {
         if ( arg != null ) {  // if there is a request POST or PUT body
             conn.setDoOutput( true );
             final HttpEntity body = (HttpEntity)encoderRegistry.getAt(
-                    requestContentType ).call( arg );
+                    requestContentType ).call( arg, requestContentType );
             // TODO configurable request charset
 
             //TODO don't override if there is a 'content-type' in the headers list


### PR DESCRIPTION
PUT and POST fail with groovy.lang.MissingMethodException if requestContentType is other than URLENC.

Sample stacktrace when requestContentType set to XML:
groovy.lang.MissingMethodException: No signature of method: groovyx.net.http.EncoderRegistry.encodeXML() is applicable for argument types: (java.util.LinkedHashMap) values: [[status:HTTPBuilder unit test was run on Sun May 25 12:37:24 CEST 2014, ...]]
