### PR TITLE
multipart/form-data body encoder support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>http-builder</artifactId>
     <groupId>org.codehaus.groovy.modules.http-builder</groupId>
-    <version>0.7.3-SNAPSHOT</version>
+    <version>0.7.3.1-SNAPSHOT</version>
     <name>HTTP client framework for Groovy</name>
     <url>http://groovy.codehaus.org/modules/http-builder/</url>
     <inceptionYear>2008</inceptionYear>
@@ -27,7 +27,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.1</version>
+            <version>4.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+            <version>1.4.01</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -434,20 +439,16 @@
 
     <distributionManagement>
         <repository>
-            <id>Groovy-Contrib</id>
-            <name>Codehaus Groovy Repo</name>
-            <url>dav:https://dav.codehaus.org/repository/gmod</url>
+            <id>mule-ee-releases</id>
+            <name>MuleSoft Release Repository</name>
+            <url>https://repository-master.mulesoft.org/nexus/content/repositories/ci-releases/</url>
         </repository>
         <snapshotRepository>
-            <id>Groovy-Contrib</id>
-            <name>Codehaus Groovy Snapshots Repo</name>
-            <url>dav:https://dav.codehaus.org/snapshots.repository/gmod</url>
+            <id>mule-ee-snapshots</id>
+            <name>MuleSoft Snapshot Repository</name>
+            <url>https://repository-master.mulesoft.org/nexus/content/repositories/ci-snapshots/</url>
+            <uniqueVersion>false</uniqueVersion>
         </snapshotRepository>
-        <site>
-            <id>Groovy-Contrib</id>
-            <name>Codehaus Groovy WebDAV</name>
-            <url>dav:https://dav.codehaus.org/groovy/modules/http-builder</url>
-        </site>
     </distributionManagement>
 
     <mailingLists>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,17 @@
             <artifactId>httpclient</artifactId>
             <version>4.2.1</version>
         </dependency>
-		<dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpmime</artifactId>
+            <version>4.3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore</artifactId>
+            <version>4.3.3</version>
+        </dependency>
+        <dependency>
             <!-- Only needed for JSON parsing -->
             <groupId>net.sf.json-lib</groupId>
             <artifactId>json-lib</artifactId>
@@ -230,7 +240,7 @@
                     </systemProperties>
                 </configuration>
             </plugin>
-            <plugin>
+           <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>cobertura-maven-plugin</artifactId>
                 <version>2.6</version>
@@ -247,13 +257,13 @@
                 </configuration>
                 <executions>
                     <!--<execution>
-                        <id>test</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>cobertura</goal>
-                        </goals>
-                    </execution>
-                    --><execution>
+                     <id>test</id>
+                     <phase>test</phase>
+                     <goals>
+                         <goal>cobertura</goal>
+                     </goals>
+                 </execution>
+                 --><execution>
                         <id>defaults</id>
                         <goals>
                             <goal>clean</goal>

--- a/src/main/java/groovyx/net/http/ContentType.java
+++ b/src/main/java/groovyx/net/http/ContentType.java
@@ -70,7 +70,9 @@ public enum ContentType {
     /** <code>application/x-www-form-urlencoded</code> */
     URLENC("application/x-www-form-urlencoded"),
     /** <code>application/octet-stream</code> */
-    BINARY("application/octet-stream");
+    BINARY("application/octet-stream"),
+    /** <code>multipart/form-data</code> */
+    MULTIPART("multipart/form-data");
 
     private final String[] ctStrings;
     public String[] getContentTypeStrings() { return ctStrings; }

--- a/src/main/java/groovyx/net/http/HttpDeleteWithBody.java
+++ b/src/main/java/groovyx/net/http/HttpDeleteWithBody.java
@@ -1,0 +1,21 @@
+package groovyx.net.http;
+
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import java.net.URI;
+import org.apache.http.annotation.NotThreadSafe;
+
+@NotThreadSafe
+class HttpDeleteWithBody extends HttpEntityEnclosingRequestBase {
+    public static final String METHOD_NAME = "DELETE";
+    public String getMethod() { return METHOD_NAME; }
+
+    public HttpDeleteWithBody(final String uri) {
+        super();
+        setURI(URI.create(uri));
+    }
+    public HttpDeleteWithBody(final URI uri) {
+        super();
+        setURI(uri);
+    }
+    public HttpDeleteWithBody() { super(); }
+}

--- a/src/main/java/groovyx/net/http/Method.java
+++ b/src/main/java/groovyx/net/http/Method.java
@@ -39,7 +39,7 @@ public enum Method {
     GET( HttpGet.class ),
     PUT( HttpPut.class ),
     POST( HttpPost.class ),
-    DELETE( HttpDelete.class ),
+    DELETE( HttpDeleteWithBody.class ),
     HEAD( HttpHead.class ),
     PATCH( HttpPatch.class );
 

--- a/src/main/java/groovyx/net/http/RESTClient.java
+++ b/src/main/java/groovyx/net/http/RESTClient.java
@@ -216,7 +216,7 @@ public class RESTClient extends HTTPBuilder {
      */
     public Object delete( Map<String,?> args ) throws URISyntaxException,
             ClientProtocolException, IOException {
-        return this.doRequest( new RequestConfigDelegate( args, new HttpDelete(), null ) );
+        return this.doRequest( new RequestConfigDelegate( args, new HttpDeleteWithBody(), null ) );
     }
 
     /**

--- a/src/main/java/groovyx/net/http/thirdparty/GAEClientConnection.java
+++ b/src/main/java/groovyx/net/http/thirdparty/GAEClientConnection.java
@@ -45,6 +45,17 @@ class GAEClientConnection
   }
 
   // From interface ManagedClientConnection
+  public String getId() {
+    return null;
+  }
+
+  public void bind(Socket socket) throws IOException {
+    throw new IOException("not supported");
+  }
+
+  public Socket getSocket() {
+    return null;
+  }
 
   public boolean isSecure() {
     return route.isSecure();

--- a/src/test/groovy/groovyx/net/http/RegistryTest.groovy
+++ b/src/test/groovy/groovyx/net/http/RegistryTest.groovy
@@ -3,8 +3,11 @@ package groovyx.net.http
 import org.apache.http.ProtocolVersion
 import org.apache.http.entity.StringEntity
 import org.apache.http.message.BasicHttpResponse
-import org.junit.Testimport java.io.StringReaderimport java.io.ByteArrayInputStream
-import static groovyx.net.http.ContentType.*
+import org.junit.Test
+import java.io.StringReader
+import java.io.ByteArrayInputStream
+import static groovyx.net.http.ContentType.*
+
 /**
  * @author tnichols
  */
@@ -188,5 +191,16 @@ public class RegistryTest {
         assert map
         assert map.p1 == 'goober'
         assert map.p2 == 'something else' 
+    }
+
+    @Test public void testMultipartEncoder() {
+        def enc = new EncoderRegistry()
+
+        def param1 = "p1"
+        def entity = enc.encodeFormMultipart( [param1:'one', p2: new File(getClass().getResource("/log4j.xml").getPath())] )
+
+        assert entity.contentType.elements[0].name == 'multipart/form-data'
+        assert entity.multipart.parts[0].header.toString() == "[Content-Disposition: form-data; name=\"param1\", Content-Type: text/plain; charset=ISO-8859-1, Content-Transfer-Encoding: 8bit]"
+        assert entity.multipart.parts[1].header.toString() == "[Content-Disposition: form-data; name=\"p2\"; filename=\"log4j.xml\", Content-Type: application/octet-stream, Content-Transfer-Encoding: binary]"
     }
 }


### PR DESCRIPTION
The intent of this change is to allow sending multipart/form-data requests.
I'm not sure if adding httpcore and httpmime libraries will prevent a merge of the pull request, but seemed to me a easy way to build a multipart entity.
