### PR TITLE
Respect property https.protocols

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.2.1</version>
+            <version>4.5.2</version>
         </dependency>
 		<dependency>
             <!-- Only needed for JSON parsing -->

--- a/src/main/java/groovyx/net/http/HTTPBuilder.java
+++ b/src/main/java/groovyx/net/http/HTTPBuilder.java
@@ -21,13 +21,15 @@
  */
 package groovyx.net.http;
 
-import com.google.appengine.repackaged.com.google.common.base.StringUtil;
 import groovy.lang.Closure;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.*;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.ResponseHandler;
 import org.apache.http.client.methods.HttpGet;
@@ -42,9 +44,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.conn.ssl.TrustStrategy;
 import org.apache.http.cookie.params.CookieSpecPNames;
-import org.apache.http.impl.client.AbstractHttpClient;
-import org.apache.http.impl.client.DefaultHttpClient;
-import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.*;
 import org.apache.http.params.BasicHttpParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
@@ -171,7 +171,7 @@ import static groovyx.net.http.URIBuilder.convertToURI;
  */
 public class HTTPBuilder {
 
-    private HttpClient client;
+	private HttpClient client;
     protected URIBuilder defaultURI = null;
     protected AuthConfig auth = new AuthConfig( this );
 
@@ -188,8 +188,14 @@ public class HTTPBuilder {
 
     protected EncoderRegistry encoders = new EncoderRegistry();
     protected ParserRegistry parsers = new ParserRegistry();
+	public static final HttpParams DEFAULT_PARAMS = new BasicHttpParams();
 
-    /**
+	static{
+		DEFAULT_PARAMS.setParameter( CookieSpecPNames.DATE_PATTERNS,
+				Arrays.asList("EEE, dd-MMM-yyyy HH:mm:ss z", "EEE, dd MMM yyyy HH:mm:ss z") );
+	}
+
+	/**
      * Creates a new instance with a <code>null</code> default URI.
      */
     public HTTPBuilder() {
@@ -832,10 +838,7 @@ public class HTTPBuilder {
      */
     public HttpClient getClient() {
         if (client == null) {
-            HttpParams defaultParams = new BasicHttpParams();
-            defaultParams.setParameter( CookieSpecPNames.DATE_PATTERNS,
-                    Arrays.asList("EEE, dd-MMM-yyyy HH:mm:ss z", "EEE, dd MMM yyyy HH:mm:ss z") );
-            client = createClient(defaultParams);
+            client = createClient(DEFAULT_PARAMS);
         }
         return client;
     }
@@ -850,22 +853,27 @@ public class HTTPBuilder {
      * @param params
      * @return
      */
-    protected HttpClient createClient( HttpParams params ) {
-        String protocols = System.getProperty("https.protocols");
-        if(StringUtils.isNotBlank(protocols)) {
-            String[] protocolArray = protocols.split(",");
-            SSLContext sslContext = SSLContexts.createDefault();
-            SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext,
-                    protocolArray,
-                    null,
-                    new NoopHostnameVerifier());
-            return HttpClients.custom().setSSLSocketFactory(sslsf).build();
+    protected HttpClient createClient( HttpParams params) {
+        if(StringUtils.isNotBlank(System.getProperty("https.protocols"))) {
+			HttpClientBuilder httpClientBuilder = getHttpClientBuilder();
+			return httpClientBuilder.build();
         } else {
             return new DefaultHttpClient(params);
         }
     }
 
-    /**
+	private HttpClientBuilder getHttpClientBuilder() {
+		String protocols = System.getProperty("https.protocols");
+		String[] protocolArray = protocols.split(",");
+		SSLContext sslContext = SSLContexts.createDefault();
+		SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslContext,
+				protocolArray,
+				null,
+				new NoopHostnameVerifier());
+		return HttpClients.custom().setSSLSocketFactory(sslsf);
+	}
+
+	/**
      * Used to access the {@link AuthConfig} handler used to configure common
      * authentication mechanism.  Example:
      * <pre>builder.auth.basic( 'myUser', 'somePassword' )</pre>
@@ -957,9 +965,14 @@ public class HTTPBuilder {
         getClient().getConnectionManager().shutdown();
     }
 
+	void setCredentials(AuthScope authScope, UsernamePasswordCredentials credentials) {
+		BasicCredentialsProvider basicCredentialsProvider = new BasicCredentialsProvider();
+		basicCredentialsProvider.setCredentials(authScope,credentials);
+		client = getHttpClientBuilder().setDefaultCredentialsProvider(basicCredentialsProvider).build();
+	}
 
 
-    /**
+	/**
      * <p>Encloses all properties and method calls used within the
      * {@link HTTPBuilder#request(Object, Method, Object, Closure)} 'config'
      * closure argument.  That is, an instance of this class is set as the

--- a/src/main/java/groovyx/net/http/thirdparty/GAEClientConnection.java
+++ b/src/main/java/groovyx/net/http/thirdparty/GAEClientConnection.java
@@ -23,6 +23,7 @@ package groovyx.net.http.thirdparty;
 
 import java.io.*;
 import java.net.*;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.http.*;
 import org.apache.http.conn.*;
@@ -34,14 +35,16 @@ import org.apache.http.protocol.*;
 
 import com.google.appengine.api.urlfetch.*;
 
-class GAEClientConnection
-  implements ManagedClientConnection {
+class GAEClientConnection implements ManagedClientConnection {
+
+  final String id;
 
   public GAEClientConnection(ClientConnectionManager cm, HttpRoute route, Object state) {
     this.connManager = cm;
     this.route = route;
     this.state = state;
     this.closed = true;
+    id = UUID.randomUUID().toString();
   }
 
   // From interface ManagedClientConnection
@@ -281,6 +284,19 @@ class GAEClientConnection
   private HTTPRequest request;
   private HTTPResponse response;
   private boolean closed;
+  private Socket socket;
 
   private static URLFetchService urlFS = URLFetchServiceFactory.getURLFetchService();
+
+  public String getId() {
+    return id;
+  }
+
+  public void bind(Socket socket) throws IOException {
+     this.socket = socket;
+  }
+
+  public Socket getSocket() {
+    return socket;
+  }
 }

--- a/src/test/groovy/groovyx/net/http/HttpURLClientTest.groovy
+++ b/src/test/groovy/groovyx/net/http/HttpURLClientTest.groovy
@@ -36,7 +36,7 @@ class HttpURLClientTest {
     @Test public void testRedirect() {
         def http = new HttpURLClient(followRedirects:false)
 
-        def params = [ url:'http://www.google.com/search',
+        def params = [ url:'https://www.google.com/search',
                         query:[q:'HTTPBuilder', btnI:"I'm Feeling Lucky"],
                         headers:['User-Agent':'Firefox'] ]
         def resp = http.request( params )


### PR DESCRIPTION
API's are disabling TLS v1 in favor of the more secure protocols TLS 1.1 or TLS 1.2. Java has a system property for setting this,  https.protocols, that this library completely ignores. Updating the library so that this property is used to set the transport protocols.

Upgrading http-client version to 4.5.2 for the SSLConnectionSocketFactory builder

Fixing testRedirect() - google redirects http - https now

Fixes issue https://github.com/jgritman/httpbuilder/issues/56
