### PR TITLE
Fix deprecated codehaus links

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ Documentation: https://github.com/jgritman/httpbuilder/wiki
 Contributions:
 
  This project relies on the work of many open source projects including:
-  * Groovy: http://groovy.codehaus.org
+  * Groovy: http://www.groovy-lang.org
   * Apache HttpClient: http://hc.apache.org
   * Json-Lib: http://json-lib.sourceforge.net/
   * Neko HTML: http://nekohtml.sourceforge.net/

--- a/README
+++ b/README
@@ -10,7 +10,7 @@ Documentation: https://github.com/jgritman/httpbuilder/wiki
 Contributions:
 
  This project relies on the work of many open source projects including:
-  * Groovy: http://www.groovy-lang.org
+  * Groovy: http://groovy-lang.org
   * Apache HttpClient: http://hc.apache.org
   * Json-Lib: http://json-lib.sourceforge.net/
   * Neko HTML: http://nekohtml.sourceforge.net/

--- a/pom.xml
+++ b/pom.xml
@@ -375,7 +375,7 @@
                         <link>http://java.sun.com/j2se/1.5.0/docs/api/</link>
                         <link>http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/</link>
                         <link>http://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/</link>
-                        <link>http://groovy-lang.org/api/</link>
+                        <link>http://groovy-lang.org/api.html</link>
                         <link>http://json-lib.sourceforge.net/apidocs/jdk15</link>
                         <link>http://xml.apache.org/commons/components/apidocs/resolver</link>
                     </links>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>org.codehaus.groovy.modules.http-builder</groupId>
     <version>0.7.3-SNAPSHOT</version>
     <name>HTTP client framework for Groovy</name>
-    <url>http://groovy.codehaus.org/modules/http-builder/</url>
+    <url>http://groovy-lang.org/modules/http-builder/</url>
     <inceptionYear>2008</inceptionYear>
 
     <description>
@@ -375,7 +375,7 @@
                         <link>http://java.sun.com/j2se/1.5.0/docs/api/</link>
                         <link>http://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/</link>
                         <link>http://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/</link>
-                        <link>http://groovy.codehaus.org/api/</link>
+                        <link>http://groovy-lang.org/api/</link>
                         <link>http://json-lib.sourceforge.net/apidocs/jdk15</link>
                         <link>http://xml.apache.org/commons/components/apidocs/resolver</link>
                     </links>

--- a/src/site/apt/doc/get.apt
+++ b/src/site/apt/doc/get.apt
@@ -17,7 +17,7 @@ Simplified GET Request
  HTML response based on the response's content-type header.  The HTML stream is
  normalized (thanks to {{{http://nekohtml.sourceforge.net/}Neko,}}) and then
  parsed by an
- {{{http://groovy.codehaus.org/Reading+XML+using+Groovy%27s+XmlSlurper}XmlSlurper}}
+ {{{http://groovy-lang.org/Reading+XML+using+Groovy%27s+XmlSlurper}XmlSlurper}}
  for easy DOM traversal.
 
  We are also taking advantage of HTTPBuilder's

--- a/src/site/apt/doc/xml.apt
+++ b/src/site/apt/doc/xml.apt
@@ -7,7 +7,7 @@
 Parsing XML data
 
   By default, HTTPBuilder classes will automatically parse XML responses using
-  an <<<{{{http://groovy.codehaus.org/gapi/groovy/util/XmlSlurper.html}XmlSlurper}}>>>.
+  an <<<{{{http://groovy-lang.org/gapi/groovy/util/XmlSlurper.html}XmlSlurper}}>>>.
 
   You can try the following example in the Groovy console (Groovy 1.6+ is needed
   for the <<<@Grab>>> macro):
@@ -44,7 +44,7 @@ Parsing XML data
 POSTing XML data
 
   XML data is serialized using
-  <<<{{{http://groovy.codehaus.org/gapi/index.html?groovy/xml/StreamingMarkupBuilder.html}StreamingMarkupBuilder}}>>>.
+  <<<{{{http://groovy-lang.org/gapi/index.html?groovy/xml/StreamingMarkupBuilder.html}StreamingMarkupBuilder}}>>>.
   You can define the <<<body>>> property as a closure like so:
 
 %{code-snippet|id=xml2|brush=groovy|file=src/site/examples.txt}

--- a/src/site/apt/download.apt.vm
+++ b/src/site/apt/download.apt.vm
@@ -33,7 +33,7 @@ Maven Users
 
 Using Grape
 
-  {{{http://groovy.codehaus.org/Grape}Grape}} is a neat dependency management
+  {{{http://groovy-lang.org/Grape}Grape}} is a neat dependency management
   feature in Groovy 1.6+ that allows you to download and add JARs to your classpath at runtime.
 
   You can automatically put HTTPBuilder in your classpath by using the following

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -206,7 +206,7 @@ News
   HTTPBuilder now 'tweets' its releases as an automated part of the build
   process.  This is a neat proof-of-concept that could easily be added to any
   Maven build thanks to
-  {{{http://groovy.codehaus.org/GMaven+-+Executing+Groovy+Code#GMaven-ExecutingGroovyCode-ExecuteaLocalGroovyScript}GMaven.}}
+  {{{http://groovy-lang.org/GMaven+-+Executing+Groovy+Code#GMaven-ExecutingGroovyCode-ExecuteaLocalGroovyScript}GMaven.}}
   See the
   {{{http://fisheye.codehaus.org/browse/gmod/httpbuilder/trunk/pom.xml?r=root:#l122}POM}}
    and

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -12,7 +12,7 @@
     <bannerRight>
         <name>Groovy</name>
         <src>http://media.xircles.codehaus.org/_projects/groovy/_logos/medium.png</src>
-        <href>http://groovy.codehaus.org/</href>
+        <href>http://groovy-lang.org/</href>
     </bannerRight>
     <version position="left" />
     <publishDate position="right"/>
@@ -46,7 +46,7 @@
             <item name="About" href="about.html" />
         </menu>
         <menu name="Additional Reference">
-            <item name="Groovy" href="http://groovy.codehaus.org/Documentation" />
+            <item name="Groovy" href="http://groovy-lang.org/Documentation" />
             <item name="HTTP/1.1 RFC" href="http://www.w3.org/Protocols/rfc2616/rfc2616.html" />
             <item name="HttpClient" href="http://hc.apache.org/httpcomponents-client/" />
             <item name="HttpCore" href="http://hc.apache.org/httpcomponents-core/" />

--- a/src/site/xdoc/about.xml
+++ b/src/site/xdoc/about.xml
@@ -19,7 +19,7 @@
       both commercial and non-commercial products.</p>
       
       <p>HTTPBuilder is built on top of a number of excellent open source 
-      products, including <a href='http://groovy.codehaus.org/'>Groovy</a>, 
+      products, including <a href='http://groovy-lang.org/'>Groovy</a>, 
       <a href='http://hc.apache.org/httpcomponents-client/'>Apache HttpClient</a>, 
       and <a href='http://json-lib.sourceforge.net/'>Json-Lib</a>.</p> 
     


### PR DESCRIPTION
I've gone ahead and fixed links to codehaus for groovy, I've tested each of these and they should now be working with the new host for groovy (groovy-lang.org).

Let me know if there's anything I can do to get this merged!